### PR TITLE
[FOOD-71] Refactor COG creation script and use band tags

### DIFF
--- a/science/README.md
+++ b/science/README.md
@@ -1,0 +1,71 @@
+# Data preparation
+This doc explains how to go from raw data to the final COG.
+It consists of 3 scripts:
+1. `calc_carbon_seq.py` which multiplies intervention's area
+suitability rasters by carbon coefficients to get the carbon sequestration potential per pixel.
+2. `upsample_raster.py` To upsample the intervention rasters from 5 arcmin to 0.05 degrees.
+3. `stack_raster.py` The one and only. This takes a list of rasters and a description csv to use as
+metadata source and band order.
+
+In order to end with a correct COG one needs to have all the data sources on hand. There is no 
+real need to have them like this, but I recommend something in the lines of.
+```
+data
+├── country
+│  ├── country.tif
+│  └── province.tif
+├── crop
+│  ├── SPAM_DominantCrop_5km.tif
+│  └── SPAM_DominantCropGroup_5km.tif
+├── foodscapes
+│  ├── Foodscapes_combinedGEOTIFF_final.tif
+│  ├── Foodscapes_combinedGEOTIFF_intensity.tif
+│  └── soil_groups.tif
+├── interventions
+│  ├── area_suitability_raster
+│  │  └── ...
+│  ├── carbon_coefficient_raster
+│  │  └── ...
+│  └── carbon_totals 
+│     └── ...
+├── risks
+│  └── ...
+└── layers_definition.csv
+
+```
+⚠ **Check that the filenames in the definition file match your locals** 
+
+All the data can be found in the gdrive of the project alongside with the layers csv.
+
+## Run the thing
+
+You need an environment (python) with rasterio, pandas, rich, click... _TODO: write a requirements.txt_
+
+All  the scripts have a nice* `--help` ;).
+
+First! compute the **carbon sequestration** per pixel at native resolution (before resampling) with  
+```shell
+python calc_carbon_seq.py --nodata 0 \
+    --area data/interventions/area_suitability_raster \
+    --carbon data/interventions/carbon_coefficient_raster \
+    --out data/interventions/carbon_totals
+```
+
+⚠ **Careful with the nodata. We are using 0.**
+
+Second! UPsample the intervention rasters to the correct resolution using a reference file.
+```shell
+python upsample_raster.py \
+  -r data/foodscapes/Foodscapes_combinedGEOTIFF_final.tif \
+  -o data/interventions/res/ \
+  data/interventions/area_suitability_raster/*.tif data/interventions/carbon_totals/*.tif
+```
+
+Third! Squeeze everything into a single COG with 30ish bands like so:
+```shell
+python stack_raster.py --cog --nodata 0 \
+  --description-file data/layers_20230215_00.csv \
+  data/foodscapes/*.tif data/crop/*.tif data/risks/*.tif data/interventions/res/*.tif data/country/country.tif data/country/province.tif \
+  data/foodscapes_cog_<YYYYMMDD>_<XX>.tif
+```
+In `stack_raster.py` the last argument is the output COG name, but check the `--help` for more.

--- a/science/calc_carbon_seq.py
+++ b/science/calc_carbon_seq.py
@@ -1,0 +1,58 @@
+from contextlib import ExitStack
+from pathlib import Path
+
+import click
+import rasterio as rio
+import rasterio.windows
+from rasterio import DatasetReader
+from rich import print
+from rich.progress import track
+
+
+def multiply_rasters(area_file: Path, carbon_coeff_file: Path, outfile: Path, nodata: int) -> None:
+    with ExitStack() as cm:
+        area_src: DatasetReader = cm.enter_context(rio.open(area_file))
+        carbon_src: DatasetReader = cm.enter_context(rio.open(carbon_coeff_file))
+        if carbon_src.crs != area_src.crs:
+            print(
+                f"[yellow]WARNING[/]: Rasters {area_file.name} and {carbon_coeff_file.name}"
+                f" don't have he same CRS:{area_src.crs} vs {carbon_src.crs}"
+            )
+
+        # use creation options from the area file
+        dest_kwargs = area_src.meta.copy()
+        dest_kwargs.update(nodata=nodata)
+        dest_src = cm.enter_context(rio.open(outfile, "w", **dest_kwargs))
+
+        area = area_src.read(1, masked=True).filled(nodata)
+        # Use windows because the carbon rasters don't have the same shape as the area rasters.
+        # (they should be having the same crs even the carbon coefficients are not tagged as 4326)
+        # The zone outside the bounds of the carbon raster will be padded with 0s
+        # thus working as if both rasters have the same shape
+        window = rio.windows.from_bounds(*area_src.bounds, transform=carbon_src.transform)
+        carbon = carbon_src.read(1, window=window, boundless=True, fill_value=0, masked=True).filled(nodata)
+        res = carbon * area
+        dest_src.write(res, indexes=1)
+
+
+@click.command(
+    help="Multiply carbon coefficients with area suitability to get the carbon potential sequestration totals"
+)
+@click.option("--area", "areas_dir", required=True, type=click.Path(exists=True, path_type=Path))
+@click.option("--carbon", "carbon_coefficient_dir", required=True, type=click.Path(exists=True, path_type=Path))
+@click.option("--out", "out_dir", required=True, type=click.Path(path_type=Path))
+@click.option("--nodata", type=int)
+def main(carbon_coefficient_dir: Path, areas_dir: Path, out_dir: Path, nodata: int):
+    area_files = [f for f in areas_dir.glob("*.tif") if f.stem.endswith("_ha")]
+    for area_file in track(area_files):
+        intervention_name = area_file.stem.split("_")[2]  # expecting `area_suit_COVERCROPS_xxxx`
+        for carbon_file in carbon_coefficient_dir.glob("*.tif"):
+            if intervention_name.lower() == carbon_file.stem.split("_")[1].lower():
+                out_name = f"Cseq_{intervention_name}.tif"
+                # print(f"{area_file.name} [yellow]*[/yellow] {carbon_file.name} [yellow]->[/yellow] {out_name}")
+                out_dir.mkdir(exist_ok=True)
+                multiply_rasters(area_file, carbon_file, out_dir / out_name, nodata)
+
+
+if __name__ == "__main__":
+    main()

--- a/science/stack_raster.py
+++ b/science/stack_raster.py
@@ -7,7 +7,6 @@ import rasterio as rio
 from rasterio import MemoryFile
 from rasterio import shutil as rio_shutil
 from rich import print, status
-from tqdm import tqdm
 
 
 @click.command(help="Create a multiband COG or tif from multiple tif files")
@@ -90,6 +89,7 @@ def stack_bands(files: list[Path], nodata: int, description_table: pd.DataFrame 
                     dest.update_tags(bidx=band_idx, **row.iloc[0].to_dict())
                 else:
                     # just set band name as filename
+                    # todo: will we use this script without csv file ever again? -> delete if/else branch
                     dest.set_band_description(band_idx, Path(file).stem)
 
                 dest.write(band_data, band_idx)
@@ -99,19 +99,23 @@ def stack_bands(files: list[Path], nodata: int, description_table: pd.DataFrame 
 
 def filter_and_order_band_list(description_file: Path | None, files: tuple[Path]) -> tuple[pd.DataFrame | None, [Path]]:
     if not description_file:
+        # todo: will we use this script without csv file ever again? -> delete if/else branch
         return None, files
     description_table = pd.read_csv(description_file, index_col=0).sort_values(by="COG_band")
-    # use the provided description file to: 1. use only the rasters defined in it
+    # use the provided description file to: use only the rasters defined in it and order the bands
     fname_order = description_table[["COG_band", "file_name"]].set_index("file_name").squeeze().to_dict()
     files_to_keep = [f for f in files if f.name in fname_order]
-    # 2. order the bands according to COG_band index value
-    files = sorted(files_to_keep, key=lambda path: fname_order[path.name])
-    return description_table, files
+
+    # check that all files described in the description file are present in the sources
+    available_file_names = {f.name for f in files}
+    for file in fname_order.keys():
+        if file not in available_file_names:
+            print(f"[yellow]WARNING[/yellow]: File {file} described in the description file not present in the sources")
+    return description_table, sorted(files_to_keep, key=lambda path: fname_order[path.name])
 
 
 def print_execution_description(cog: bool, files: tuple[Path], nodata: int | None, output: Path):
     """Just displays what the command is about to do
-
     Can help to avoid a catastrophe in the case of messing the args up
     """
     print(f"[bold]About to stack the following files{' as multiband COG' if cog else ' multiband GTiff'}:[/bold]")
@@ -120,7 +124,7 @@ def print_execution_description(cog: bool, files: tuple[Path], nodata: int | Non
     if nodata is not None:
         print(f"And replace [bold]nodata[/bold] with: {nodata}")
     else:
-        print("Nodata will be kept as it is")
+        print("Nodata will be kept as it is in each file.")
     click.confirm("Do you want to continue?", abort=True)
 
 

--- a/science/stack_raster.py
+++ b/science/stack_raster.py
@@ -1,73 +1,127 @@
 from pathlib import Path
 
-import numpy as np
-import rasterio as rio
 import click
-from rasterio import MemoryFile, DatasetReader
+import numpy as np
+import pandas as pd
+import rasterio as rio
+from rasterio import MemoryFile
 from rasterio import shutil as rio_shutil
+from rich import print, status
 from tqdm import tqdm
-from rich import print
-from rio_cogeo import cog_profiles, cog_translate
 
 
 @click.command(help="Create a multiband COG or tif from multiple tif files")
-@click.argument("files", nargs=-1, type=click.Path(exists=True))
-@click.argument("output", nargs=1, type=click.Path())
+@click.argument("files", nargs=-1, type=click.Path(exists=True, path_type=Path))
+@click.argument("output", nargs=1, type=click.Path(path_type=Path))
 @click.option(
     "--nodata", type=int, help="set no data value. This will also replace the old no data values with the new one."
 )
 @click.option("--cog", is_flag=True, help="Make output a cog")
-def main(files: tuple[click.Path], output: click.Path, nodata: int | None, cog: bool):
-    print(f"[bold]About to stack the following files{' as multiband COG' if cog else ' multiband GTiff'}:[/bold]")
-    print("\n".join("\t" + Path(str(f)).name for f in files))
-    print(f"Into: {Path(output).resolve()}")
-    if nodata is not None:
-        print(f"[bold]And replace nodata with:[/bold] {nodata}")
-    else:
-        print("Nodata will be kept as it is")
-    click.confirm("Do you want to continue?", abort=True)
+@click.option(
+    "--description-file",
+    "description_file",
+    type=click.Path(exists=True, path_type=Path),
+    help="Use the band description csv to set the band metadata and order",
+)
+def main(files: tuple[Path], output: Path, nodata: int | None, cog: bool, description_file: Path | None):
+    description_table, files = filter_and_order_band_list(description_file, files)
+    print_execution_description(cog, files, nodata, output)
+    stacked_raster, dest_kwargs = stack_bands(files, nodata, description_table)
+    with stacked_raster.open() as src:
+        if cog:
+            indicator = status.Status("Converting to COG...", spinner="earth", refresh_per_second=5)
+            indicator.start()
+            dest_kwargs.update(
+                {
+                    "driver": "COG",
+                    "TILING_SCHEME": "GoogleMapsCompatible",
+                    "ZOOM_LEVEL_STRATEGY": "upper",
+                    "overview_resampling": "nearest",
+                    "warp_resampling": "nearest",
+                    "blocksize": 512,
+                }
+            )
+            rio_shutil.copy(src, output, **dest_kwargs)
+            indicator.stop()
+            print("Done")
 
-    src: DatasetReader
+        else:
+            print(f"Writing file {output} ...")
+            rio_shutil.copy(src, output, **dest_kwargs)
+
+
+def stack_bands(files: list[Path], nodata: int, description_table: pd.DataFrame | None) -> tuple[MemoryFile, dict]:
+    """Join all files from list into a MemoryFile with multiple bands"""
     with rio.open(files[0]) as src:
         # read first file and use it as template for the metadata
         dest_kwargs = src.meta.copy()
         first_crs = src.crs
-    dest_kwargs.update(**cog_profiles.get("deflate"))
-    dest_kwargs.update(nodata=nodata, count=len(files), interleave="band", dtype="float32")
-
-    with MemoryFile().open(**dest_kwargs) as mem_dst:
-        print("Collecting bands and writing nodata...")
-        pbar = tqdm(files)
-        for i, file in enumerate(pbar):
+    dest_kwargs.update(
+        {
+            "driver": "GTiff",
+            "interleave": "pixel",
+            "tiled": True,
+            "blockxsize": 512,
+            "blockysize": 512,
+            "compress": "DEFLATE",
+            "nodata": nodata,
+            "count": len(files),
+            "dtype": "float32",
+        }
+    )
+    mem_file = MemoryFile()
+    with mem_file.open(**dest_kwargs) as dest:
+        indicator = status.Status("Collecting bands and writing nodata", spinner="moon")
+        indicator.start()
+        for i, file in enumerate(files):
+            band_idx = i + 1
             with rio.open(file) as src:
                 if src.crs != first_crs:
                     raise ValueError(
                         f"file {file} has a different CRS " f" from {files[0]} with {src.crs} and {first_crs}"
                     )
-                band = src.read(1)
+                band_data = src.read(1)
                 if (nodata is not None) & (src.nodata != nodata):
-                    # print(f"Replacing {src.nodata} with {nodata} in {file}")
-                    band = np.where(band == src.nodata, nodata, band)
+                    band_data = np.where(band_data == src.nodata, nodata, band_data)
 
-                mem_dst.write(band, i + 1)
-                mem_dst.set_band_description(i + 1, Path(file).stem)
-        if cog:
-            print("Converting to COG...")
-            # TODO: find the way to do it fine grained with the gdal ?
-            # Since GDAL 3.2 includes the COG driver rio cogeo doesn't make that much sense
-            cog_translate(
-                mem_dst,
-                output,
-                dest_kwargs,
-                in_memory=True,
-                quiet=False,
-                web_optimized=True,
-                use_cog_driver=True,
-                zoom_level_strategy="upper",
-            )
-        else:
-            print(f"Writing file {output} ...")
-            rio_shutil.copy(mem_dst, output, **dest_kwargs)
+                if description_table is not None:
+                    row: pd.DataFrame
+                    row = description_table.loc[description_table["file_name"] == Path(file).name]
+                    dest.update_tags(bidx=band_idx, **row.iloc[0].to_dict())
+                else:
+                    # just set band name as filename
+                    dest.set_band_description(band_idx, Path(file).stem)
+
+                dest.write(band_data, band_idx)
+        indicator.stop()
+    return mem_file, dest_kwargs
+
+
+def filter_and_order_band_list(description_file: Path | None, files: tuple[Path]) -> tuple[pd.DataFrame | None, [Path]]:
+    if not description_file:
+        return None, files
+    description_table = pd.read_csv(description_file, index_col=0).sort_values(by="COG_band")
+    # use the provided description file to: 1. use only the rasters defined in it
+    fname_order = description_table[["COG_band", "file_name"]].set_index("file_name").squeeze().to_dict()
+    files_to_keep = [f for f in files if f.name in fname_order]
+    # 2. order the bands according to COG_band index value
+    files = sorted(files_to_keep, key=lambda path: fname_order[path.name])
+    return description_table, files
+
+
+def print_execution_description(cog: bool, files: tuple[Path], nodata: int | None, output: Path):
+    """Just displays what the command is about to do
+
+    Can help to avoid a catastrophe in the case of messing the args up
+    """
+    print(f"[bold]About to stack the following files{' as multiband COG' if cog else ' multiband GTiff'}:[/bold]")
+    print("\n".join("\t" + Path(str(f)).name for f in files))
+    print(f"Into: {Path(output).resolve()}")
+    if nodata is not None:
+        print(f"And replace [bold]nodata[/bold] with: {nodata}")
+    else:
+        print("Nodata will be kept as it is")
+    click.confirm("Do you want to continue?", abort=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add option to use metadata table to set as band tags and refactors file

If the .csv is provided it will be used to filter which bands are used and the order. Gets rid of the `rio_cogeo` cog constructor because with the "new" COG driver of GDAL it is not needed anymore. Also I tried to reorganize a bit the file with relative luck.