### PR TITLE
Fix API calls on vercel

### DIFF
--- a/client/src/pages/api/agroforestries/data.ts
+++ b/client/src/pages/api/agroforestries/data.ts
@@ -65,7 +65,7 @@ const fetch = async (filters: FiltersProps) => {
 
 const AgroforestriesData = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
-    const filters = qs.parseUrl(req.url, {
+    const filters = qs.parseUrl(decodeURIComponent(req.url), {
       parseNumbers: true,
       parseBooleans: true,
       arrayFormat: 'bracket-separator',

--- a/client/src/pages/api/climate-risks/data.ts
+++ b/client/src/pages/api/climate-risks/data.ts
@@ -42,7 +42,7 @@ const fetch = async (filters: FiltersProps) => {
 
 const ClimateRisksData = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
-    const filters = qs.parseUrl(req.url, {
+    const filters = qs.parseUrl(decodeURIComponent(req.url), {
       parseNumbers: true,
       parseBooleans: true,
       arrayFormat: 'bracket-separator',

--- a/client/src/pages/api/countries/data.ts
+++ b/client/src/pages/api/countries/data.ts
@@ -36,7 +36,7 @@ const fetch = async (filters: FiltersProps) => {
 
 const CountriesData = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
-    const filters = qs.parseUrl(req.url, {
+    const filters = qs.parseUrl(decodeURIComponent(req.url), {
       parseNumbers: true,
       parseBooleans: true,
       arrayFormat: 'bracket-separator',

--- a/client/src/pages/api/crops/data.ts
+++ b/client/src/pages/api/crops/data.ts
@@ -39,7 +39,7 @@ const CropsData = async (
   res: NextApiResponse<CropData[] | { error: string }>
 ) => {
   try {
-    const filters = qs.parseUrl(req.url, {
+    const filters = qs.parseUrl(decodeURIComponent(req.url), {
       parseNumbers: true,
       parseBooleans: true,
       arrayFormat: 'bracket-separator',

--- a/client/src/pages/api/foodscapes-intensities/data.ts
+++ b/client/src/pages/api/foodscapes-intensities/data.ts
@@ -39,7 +39,7 @@ const FoodscapeIntensitiesData = async (
   res: NextApiResponse<FoodscapeIntensityData[] | { error: string }>
 ) => {
   try {
-    const filters = qs.parseUrl(req.url, {
+    const filters = qs.parseUrl(decodeURIComponent(req.url), {
       parseNumbers: true,
       parseBooleans: true,
       arrayFormat: 'bracket-separator',

--- a/client/src/pages/api/foodscapes-summary/data.ts
+++ b/client/src/pages/api/foodscapes-summary/data.ts
@@ -33,7 +33,7 @@ const fetch = async (params: DatasetteParamsProps) => {
 
 const FoodscapesData = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
-    const params = qs.parseUrl(req.url, {
+    const params = qs.parseUrl(decodeURIComponent(req.url), {
       parseNumbers: true,
       parseBooleans: true,
       arrayFormat: 'bracket-separator',

--- a/client/src/pages/api/foodscapes/data.ts
+++ b/client/src/pages/api/foodscapes/data.ts
@@ -46,7 +46,7 @@ const FoodscapesData = async (
   res: NextApiResponse<FoodscapeData[] | { error: string }>
 ) => {
   try {
-    const params = qs.parseUrl(req.url, {
+    const params = qs.parseUrl(decodeURIComponent(req.url), {
       parseNumbers: true,
       parseBooleans: true,
       arrayFormat: 'bracket-separator',

--- a/client/src/pages/api/foodscapes/data.ts
+++ b/client/src/pages/api/foodscapes/data.ts
@@ -23,13 +23,6 @@ const fetch = async (params: DatasetteParamsProps) => {
     .whereNotIn('d.foodscapes', [1, 2, 3])
     .groupBy('d.foodscapes');
 
-  console.log(
-    datasetteAdapter({
-      sql: SQL,
-      shape: 'array',
-      ...params,
-    })
-  );
   return API.request<FoodscapeData[]>({
     method: 'GET',
     url: '/foodscapes.json',
@@ -52,41 +45,6 @@ const FoodscapesData = async (
       arrayFormat: 'bracket-separator',
       arrayFormatSeparator: ',',
     }).query as DatasetteParamsProps;
-
-    console.log({
-      url: req.url,
-      query: req.query,
-      'bracket-separator': qs.parseUrl(req.url, {
-        parseNumbers: true,
-        parseBooleans: true,
-        arrayFormat: 'bracket-separator',
-        arrayFormatSeparator: ',',
-      }).query,
-      bracket: qs.parseUrl(req.url, {
-        parseNumbers: true,
-        parseBooleans: true,
-        arrayFormat: 'bracket',
-        arrayFormatSeparator: ',',
-      }).query,
-      comma: qs.parseUrl(req.url, {
-        parseNumbers: true,
-        parseBooleans: true,
-        arrayFormat: 'comma',
-        arrayFormatSeparator: ',',
-      }).query,
-      index: qs.parseUrl(req.url, {
-        parseNumbers: true,
-        parseBooleans: true,
-        arrayFormat: 'index',
-        arrayFormatSeparator: ',',
-      }).query,
-      separator: qs.parseUrl(req.url, {
-        parseNumbers: true,
-        parseBooleans: true,
-        arrayFormat: 'separator',
-        arrayFormatSeparator: ',',
-      }).query,
-    });
 
     const result = await fetch(params);
     res.status(200).json(result);

--- a/client/src/pages/api/foodscapes/data.ts
+++ b/client/src/pages/api/foodscapes/data.ts
@@ -53,7 +53,40 @@ const FoodscapesData = async (
       arrayFormatSeparator: ',',
     }).query as DatasetteParamsProps;
 
-    console.log({ params, query: req.query });
+    console.log({
+      url: req.url,
+      query: req.query,
+      'bracket-separator': qs.parseUrl(req.url, {
+        parseNumbers: true,
+        parseBooleans: true,
+        arrayFormat: 'bracket-separator',
+        arrayFormatSeparator: ',',
+      }).query,
+      bracket: qs.parseUrl(req.url, {
+        parseNumbers: true,
+        parseBooleans: true,
+        arrayFormat: 'bracket',
+        arrayFormatSeparator: ',',
+      }).query,
+      comma: qs.parseUrl(req.url, {
+        parseNumbers: true,
+        parseBooleans: true,
+        arrayFormat: 'comma',
+        arrayFormatSeparator: ',',
+      }).query,
+      index: qs.parseUrl(req.url, {
+        parseNumbers: true,
+        parseBooleans: true,
+        arrayFormat: 'index',
+        arrayFormatSeparator: ',',
+      }).query,
+      separator: qs.parseUrl(req.url, {
+        parseNumbers: true,
+        parseBooleans: true,
+        arrayFormat: 'separator',
+        arrayFormatSeparator: ',',
+      }).query,
+    });
 
     const result = await fetch(params);
     res.status(200).json(result);

--- a/client/src/pages/api/land-use-risks/data.ts
+++ b/client/src/pages/api/land-use-risks/data.ts
@@ -74,7 +74,7 @@ const fetch = async (filters: FiltersProps) => {
 
 const LandUseRisksData = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
-    const filters = qs.parseUrl(req.url, {
+    const filters = qs.parseUrl(decodeURIComponent(req.url), {
       parseNumbers: true,
       parseBooleans: true,
       arrayFormat: 'bracket-separator',

--- a/client/src/pages/api/locations/data.ts
+++ b/client/src/pages/api/locations/data.ts
@@ -36,7 +36,7 @@ const fetch = async (filters: FiltersProps) => {
 
 const LocationsData = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
-    const filters = qs.parseUrl(req.url, {
+    const filters = qs.parseUrl(decodeURIComponent(req.url), {
       parseNumbers: true,
       parseBooleans: true,
       arrayFormat: 'bracket-separator',

--- a/client/src/pages/api/pollution-risks/data.ts
+++ b/client/src/pages/api/pollution-risks/data.ts
@@ -42,7 +42,7 @@ const fetch = async (filters: FiltersProps) => {
 
 const PollutionRisksData = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
-    const filters = qs.parseUrl(req.url, {
+    const filters = qs.parseUrl(decodeURIComponent(req.url), {
       parseNumbers: true,
       parseBooleans: true,
       arrayFormat: 'bracket-separator',

--- a/client/src/pages/api/provinces/data.ts
+++ b/client/src/pages/api/provinces/data.ts
@@ -36,7 +36,7 @@ const fetch = async (filters: FiltersProps) => {
 
 const ProvincesData = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
-    const filters = qs.parseUrl(req.url, {
+    const filters = qs.parseUrl(decodeURIComponent(req.url), {
       parseNumbers: true,
       parseBooleans: true,
       arrayFormat: 'bracket-separator',

--- a/client/src/pages/api/restorations/data.ts
+++ b/client/src/pages/api/restorations/data.ts
@@ -52,7 +52,7 @@ const fetch = async (filters: FiltersProps) => {
 
 const RestorationsData = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
-    const filters = qs.parseUrl(req.url, {
+    const filters = qs.parseUrl(decodeURIComponent(req.url), {
       parseNumbers: true,
       parseBooleans: true,
       arrayFormat: 'bracket-separator',

--- a/client/src/pages/api/soil-healths/data.ts
+++ b/client/src/pages/api/soil-healths/data.ts
@@ -52,7 +52,7 @@ const fetch = async (filters: FiltersProps) => {
 
 const SoilHealthsData = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
-    const filters = qs.parseUrl(req.url, {
+    const filters = qs.parseUrl(decodeURIComponent(req.url), {
       parseNumbers: true,
       parseBooleans: true,
       arrayFormat: 'bracket-separator',

--- a/client/src/services/api/index.ts
+++ b/client/src/services/api/index.ts
@@ -5,39 +5,6 @@ const API = axios.create({
   baseURL: `/api`,
   headers: { 'Content-Type': 'application/json' },
   paramsSerializer: (params) => {
-    console.log({
-      params,
-      'bracket-separator': qs.stringify(params, {
-        arrayFormat: 'bracket-separator',
-        arrayFormatSeparator: ',',
-        skipNull: true,
-        skipEmptyString: true,
-      }),
-      bracket: qs.stringify(params, {
-        arrayFormat: 'bracket',
-        arrayFormatSeparator: ',',
-        skipNull: true,
-        skipEmptyString: true,
-      }),
-      comma: qs.stringify(params, {
-        arrayFormat: 'comma',
-        arrayFormatSeparator: ',',
-        skipNull: true,
-        skipEmptyString: true,
-      }),
-      index: qs.stringify(params, {
-        arrayFormat: 'index',
-        arrayFormatSeparator: ',',
-        skipNull: true,
-        skipEmptyString: true,
-      }),
-      separator: qs.stringify(params, {
-        arrayFormat: 'separator',
-        arrayFormatSeparator: ',',
-        skipNull: true,
-        skipEmptyString: true,
-      }),
-    });
     return qs.stringify(params, {
       arrayFormat: 'bracket-separator',
       arrayFormatSeparator: ',',

--- a/client/src/services/api/index.ts
+++ b/client/src/services/api/index.ts
@@ -5,16 +5,39 @@ const API = axios.create({
   baseURL: `/api`,
   headers: { 'Content-Type': 'application/json' },
   paramsSerializer: (params) => {
-    console.log(
-      'params',
+    console.log({
       params,
-      qs.stringify(params, {
+      'bracket-separator': qs.stringify(params, {
         arrayFormat: 'bracket-separator',
         arrayFormatSeparator: ',',
         skipNull: true,
         skipEmptyString: true,
-      })
-    );
+      }),
+      bracket: qs.stringify(params, {
+        arrayFormat: 'bracket',
+        arrayFormatSeparator: ',',
+        skipNull: true,
+        skipEmptyString: true,
+      }),
+      comma: qs.stringify(params, {
+        arrayFormat: 'comma',
+        arrayFormatSeparator: ',',
+        skipNull: true,
+        skipEmptyString: true,
+      }),
+      index: qs.stringify(params, {
+        arrayFormat: 'index',
+        arrayFormatSeparator: ',',
+        skipNull: true,
+        skipEmptyString: true,
+      }),
+      separator: qs.stringify(params, {
+        arrayFormat: 'separator',
+        arrayFormatSeparator: ',',
+        skipNull: true,
+        skipEmptyString: true,
+      }),
+    });
     return qs.stringify(params, {
       arrayFormat: 'bracket-separator',
       arrayFormatSeparator: ',',


### PR DESCRIPTION
It seems that the api calls in vercel are encoded so we need to `decodeURIComponent` the `req.url` to get the filter params correctly when we use `query-string`

Good:
`http://localhost:3000/api/foodscapes/data?climateRisk[]&crops[]=29,28,22,21,23,27,25,26,20,24,12,13,9,10,11,14,15,16,19,17&foodscapes[]=602,506,508&intensities[]&landUseRisk[]&pollutionRisk[]`

Bad:
`'http://localhost:3000/api/foodscapes/data?climateRisk%5B%5D&crops%5B%5D=29,28,22,21,23,27,25,26,20,24,12,13,9,10,11,14,15,16,19,17&foodscapes%5B%5D=602,506,508&intensities%5B%5D&landUseRisk%5B%5D&pollutionRisk%5B%5D'`