### PR TITLE
[FOOD-342, FOOD-343] Tiler for raster contextual layers

### DIFF
--- a/tiler/app/factory.py
+++ b/tiler/app/factory.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+from typing import Type, Literal
+
+from rio_tiler.io import BaseReader, Reader
+from titiler.core import TilerFactory
+
+
+@dataclass
+class SimpleTiler(TilerFactory):
+    """Simple Tiler with /tile and /point endpoints only."""
+
+    def register_routes(self):
+        self.tile()
+        self.point()

--- a/tiler/app/main.py
+++ b/tiler/app/main.py
@@ -1,10 +1,20 @@
-from fastapi import FastAPI, Query
 from os import getenv, environ
+from pathlib import Path
+
+from fastapi import FastAPI
 from titiler.core import TilerFactory
 from titiler.core.errors import DEFAULT_STATUS_CODES, add_exception_handlers
 from titiler.core.middleware import TotalTimeMiddleware, LoggerMiddleware
 
+from .factory import SimpleTiler
 from .utils.cors_middleware import add_cors_middleware
+
+
+def url_from_env_var(env_var_name: str) -> str:
+    """Return a default URL for a COG from an environment variable."""
+    url = Path(environ["DATA_HOME"]) / Path(getenv(env_var_name, ""))
+    return url.as_posix() if getenv(env_var_name, "") else ""
+
 
 ROOT_PATH = getenv("TILER_ROOT_PATH", "")
 
@@ -12,33 +22,43 @@ ROOT_PATH = getenv("TILER_ROOT_PATH", "")
 # otherwise leave COG_PATH empty. DATA_HOME should always be defined (it's baked
 # in the Docker image), so we can let getenv fail if it happens to be not
 # defined as that would be an unexpected situation.
-COG_PATH = (
-    f"{environ['DATA_HOME']}/{getenv('TILER_FOODSCAPES_COG_FILENAME', '')}"
-    if getenv("TILER_FOODSCAPES_COG_FILENAME", "")
-    else ""
-)
+COG_PATH = url_from_env_var("TILER_FOODSCAPES_COG_FILENAME")
+IRRECOVERABLE_CARBON_COG_PATH = url_from_env_var("TILER_IRRECOVERABLE_CARBON_COG_FILENAME")
+DEPRIVATION_INDEX_COG_PATH = url_from_env_var("TILER_DEPRIVATION_INDEX_COG_FILENAME")
 
 
-def default_cog_url(url: str | None = Query(default=None, description="Optional dataset URL")) -> str:
-    """Makes the cog path url parameter optional.
-    If no url is provided, default to COG_PATH defined at app startup.
-    """
-    if url:
-        return url
-    else:
-        return COG_PATH
+def default_foodscapes_cog_url() -> str:
+    return COG_PATH
 
 
-app = FastAPI(title="Tiler!", root_path=ROOT_PATH)
+def default_irrecoverable_carbon_cog_url() -> str:
+    return IRRECOVERABLE_CARBON_COG_PATH
+
+
+def default_deprivation_index_cog_url() -> str:
+    return DEPRIVATION_INDEX_COG_PATH
+
+
+app = FastAPI(title="Foodscapes Tiler", root_path=ROOT_PATH)
 app.add_middleware(TotalTimeMiddleware)
 app.add_middleware(LoggerMiddleware)
 app = add_cors_middleware(app)
-
-# single COG tiler. One file can have multiple bands
-cog = TilerFactory(router_prefix="/cog", path_dependency=default_cog_url)
-app.include_router(cog.router, tags=["Cloud Optimized GeoTIFF"], prefix="/cog")
-
 add_exception_handlers(app, DEFAULT_STATUS_CODES)
+
+# main tiler for foodscapes COG
+foodscapes_tiler = TilerFactory(router_prefix="/cog/foodscapes", path_dependency=default_foodscapes_cog_url)
+app.include_router(foodscapes_tiler.router, tags=["foodscapes"], prefix="/cog/foodscapes")
+
+# Contextual layers tilers
+irrecoverable_carbon_tiler = SimpleTiler(
+    router_prefix="/cog/irrecoverable_carbon", path_dependency=default_irrecoverable_carbon_cog_url
+)
+app.include_router(irrecoverable_carbon_tiler.router, tags=["irrecoverable carbon"], prefix="/cog/irrecoverable_carbon")
+
+deprivation_index_tiler = SimpleTiler(
+    router_prefix="/cog/deprivation_index", path_dependency=default_deprivation_index_cog_url
+)
+app.include_router(deprivation_index_tiler.router, tags=["Relative deprivation index"], prefix="/cog/deprivation_index")
 
 
 @app.get("/healthz", description="Health Check", tags=["Health Check"])


### PR DESCRIPTION
This PR adds to new tiler routes (`/cog/irrecoverable_carbon` and `/cog/deprivation_index`) to get the contextual layers tiles. 

It creates a simpler tiler factory since we should not need to use as much as machinery as the main foodscapes cog.
The url is defined as in the base cog, via the new env vars `TILER_IRRECOVERABLE_CARBON_COG_FILENAME` and `TILER_DEPRIVATION_INDEX_COG_FILENAME`
